### PR TITLE
Recommend ncp-uart-sw_679_115200 instead of ncp-uart-nsw_679_115200

### DIFF
--- a/firmware/Zigbee3.0_Dongle/README.md
+++ b/firmware/Zigbee3.0_Dongle/README.md
@@ -12,7 +12,7 @@ Nopte! Flashing custom firmwares may void your warranty. Use at your own Risk!
 
 Currenly recommended firmware for the zigpy/bellows based ZHA integration in Home Assistant:
 
-- ncp-uart-nsw_679_115200.gbl
+- ncp-uart-sw_679_115200.gbl
 
 ## Versions and changelog
 


### PR DESCRIPTION
Recommend ncp-uart-sw_679_115200.gbl instead of ncp-uart-nsw_679_115200.gbl as Software Flow Control (SW) is recommended by ZHA and bellows / zigpy developers.