### PR TITLE
Recommend higher values in firmware for "pro" configuration

### DIFF
--- a/firmware/Zigbee3.0_Dongle/README.md
+++ b/firmware/Zigbee3.0_Dongle/README.md
@@ -73,7 +73,7 @@ Firmware Configuration Parameter | Value | Description as seen in ZHA zigpy ezsp
 Part | EFR32MG21A020F768IM32 | Silicon Labs EFR32MG21 Series 2 Multiprotocol Wireless SoC
 CTUNE value | 128 |  CTune HFXO Capacitor Bank calibration value
 Address Table Size | 32| CONFIG_ADDRESS_TABLE_SIZE
-Child Table Size | 64 | CONFIG_MAX_END_DEVICE_CHILDREN
+Child Table Size | 32 | CONFIG_MAX_END_DEVICE_CHILDREN
 Source Routes | 200 | CONFIG_SOURCE_ROUTE_TABLE_SIZE
 ? | 16 | CONFIG_ROUTE_TABLE_SIZE
 ? | 30 | CONFIG_APS_UNICAST_MESSAGE_COUNT

--- a/firmware/Zigbee3.0_Dongle/README.md
+++ b/firmware/Zigbee3.0_Dongle/README.md
@@ -59,6 +59,8 @@ Commonly used shorthand and acronyms used in firmware image file names for Silab
 
 #### EmberZNet NCP Zigbee application firmware
 
+EmberZNet NCP Zigbee application configuration parameters when building Silabs EmberZNet firmware for ITead Zigbee 3.0 USB Dongle Model 9888010100045
+
 EFR32MG21 target
 NCP UART TX --> PA0
 NCP UART RC <-- PA1
@@ -68,6 +70,7 @@ DCDC
 
 Firmware Configuration Parameter | Value | Description as seen in ZHA zigpy ezsp config
 -------------------------------- | ----- | ----------------------------------------------
+Part | EFR32MG21A020F768IM32 | Silicon Labs EFR32MG21 Series 2 Multiprotocol Wireless SoC
 CTUNE value | 128 |  CTune HFXO Capacitor Bank calibration value
 Address Table Size | 32| CONFIG_ADDRESS_TABLE_SIZE
 Child Table Size | 64 | CONFIG_MAX_END_DEVICE_CHILDREN
@@ -77,6 +80,10 @@ Source Routes | 200 | CONFIG_SOURCE_ROUTE_TABLE_SIZE
 ? | 254 | CONFIG_PACKET_BUFFER_COUNT
 ? | 32 | CONFIG_BINDING_TABLE_SIZE
 ? | 26 | CONFIG_NEIGHBOR_TABLE_SIZE
+TX | PA00 | EFR32MG21 chip pin for Transmitter Data (TXD)
+RX | PA01 | EFR32MG21 chippin  for Receiving Data (RXD)
+RTS | PC01 | EFR32MG21 chip pin RTS (Request to Send) for hardware flow control
+CTS | PC00 | EFR32MG21 chip pin CTS (Clear to Send) for hardware flow control
 
 The remaining parameters are at the default values.
 

--- a/firmware/Zigbee3.0_Dongle/README.md
+++ b/firmware/Zigbee3.0_Dongle/README.md
@@ -80,12 +80,18 @@ Source Routes | 200 | CONFIG_SOURCE_ROUTE_TABLE_SIZE
 ? | 254 | CONFIG_PACKET_BUFFER_COUNT
 ? | 32 | CONFIG_BINDING_TABLE_SIZE
 ? | 26 | CONFIG_NEIGHBOR_TABLE_SIZE
-TX | PA00 | EFR32MG21 chip pin for Transmitter Data (TXD)
-RX | PA01 | EFR32MG21 chippin  for Receiving Data (RXD)
+GND | ? | Ground
+TX | PB01 | EFR32MG21 chip pin for Transmitter Data (TXD)
+RX | PB00 | EFR32MG21 chippin  for Receiving Data (RXD)
+LED | PC00 | LED
+BTL | PA00 | "BOOT" button for Bootloader
+RST | ? | Reset Z_RST (nRST)
 RTS | PC01 | EFR32MG21 chip pin RTS (Request to Send) for hardware flow control
 CTS | PC00 | EFR32MG21 chip pin CTS (Clear to Send) for hardware flow control
 
 The remaining parameters are at the default values.
+
+Note! RTS and CTS is not connected from EFR32MG21 to CH340 USB-to-Serial-chip on V1.3 of ITead Zigbee 3.0 USB Dongle Model 9888010100045.
 
 #### Gecko Bootloader firmware
 

--- a/firmware/Zigbee3.0_Dongle/README.md
+++ b/firmware/Zigbee3.0_Dongle/README.md
@@ -84,7 +84,7 @@ GND | ? | Ground
 TX | PB01 | EFR32MG21 chip pin for Transmitter Data (TXD)
 RX | PB00 | EFR32MG21 chippin  for Receiving Data (RXD)
 LED | PC00 | LED
-BTL | PA00 | "BOOT" button for Bootloader
+BTL | PA00 | "BOOT" button for Bootloader (Low = BTL boot)
 RST | ? | Reset Z_RST (nRST)
 RTS | PC01 | EFR32MG21 chip pin RTS (Request to Send) for hardware flow control
 CTS | PC00 | EFR32MG21 chip pin CTS (Clear to Send) for hardware flow control

--- a/firmware/Zigbee3.0_Dongle/README.md
+++ b/firmware/Zigbee3.0_Dongle/README.md
@@ -66,12 +66,17 @@ EZSP Version 8
 EmberZNet 6.7.9
 DCDC
 
-Configuration Parameter | Value
------------------------ | ------
-Address Table Size | 8
-Child Table Size | 32
-Source Routes | 7
-CTUNE value | 128
+Firmware Configuration Parameter | Value | Description as seen in ZHA zigpy ezsp config
+-------------------------------- | ----- | ----------------------------------------------
+CTUNE value | 128 |  CTune HFXO Capacitor Bank calibration value
+Address Table Size | 32| CONFIG_ADDRESS_TABLE_SIZE
+Child Table Size | 64 | CONFIG_MAX_END_DEVICE_CHILDREN
+Source Routes | 200 | CONFIG_SOURCE_ROUTE_TABLE_SIZE
+? | 16 | CONFIG_ROUTE_TABLE_SIZE
+? | 30 | CONFIG_APS_UNICAST_MESSAGE_COUNT
+? | 254 | CONFIG_PACKET_BUFFER_COUNT
+? | 32 | CONFIG_BINDING_TABLE_SIZE
+? | 26 | CONFIG_NEIGHBOR_TABLE_SIZE
 
 The remaining parameters are at the default values.
 


### PR DESCRIPTION
@xsp1989  Recommend higher values in firmware for "pro" configuration as per https://github.com/zigpy/bellows/pull/397 and https://github.com/xsp1989/zigbeeFirmware/issues/6

This is already supported in software like Home Assistant and EFR32MG21 based devices can handle these increase these values.

Configuration Parameter | Value
----------------------- | ------
Address Table Size | 32
Child Table Size | 32
Source Routes | 200


Configuration Parameter | Value
-- | --
Part | EFR32MG21A020F768IM32
Version | EZSP 6.10.1.0
CTUNE value | 128
Address Table Size | 32
Child Table Size | 32
Source Routes | 200
TX | PB01
RX | PB00
CTS | ?
RTS | ?
BTL | PA00 (Low = BTL boot)
LED | PC00 

See example of used in real life 

https://github.com/tube0013/tube_gateways/blob/main/tube_zb_gw_efr32/README.md

 # Specific Configuration for the Tube EFR32 Gateways
Because the EFR32 gateways uses some firrmware settings different than the bellows defaults it is recommended set them in the configuration.yaml so bellows will utilize them.


## For EFR32 Series 2 Gateways with Firmware based on the 6.9.2 SDK or later please use the following config
**Add these lines to your configuration.yaml file:**

```
zha:
  zigpy_config:
    source_routing: true
    ezsp_config:
      CONFIG_APS_UNICAST_MESSAGE_COUNT: 64
      CONFIG_MAX_END_DEVICE_CHILDREN: 32
      CONFIG_SOURCE_ROUTE_TABLE_SIZE: 200
      CONFIG_ROUTE_TABLE_SIZE: 16
      CONFIG_ADDRESS_TABLE_SIZE: 32
      CONFIG_PACKET_BUFFER_COUNT: 250
      CONFIG_BINDING_TABLE_SIZE: 32
      CONFIG_NEIGHBOR_TABLE_SIZE: 26
```

