### PR TITLE
Mention "hw" (hardware flow control) in abbreviations legend

### DIFF
--- a/firmware/Zigbee3.0_Dongle/README.md
+++ b/firmware/Zigbee3.0_Dongle/README.md
@@ -39,7 +39,8 @@ Commonly used shorthand and acronyms used in firmware image file names for Silab
 * com = Combined (necessary for EFR32 Series 1)
 * uart = UART interface
 * nsw = no flow control
-* sw = software flow control
+* sw = software flow control (XON/XOFF flow control)
+* hw = hardware flow control (RTS/CTS flow control)
 * 655 / 678 / 679 = EmberZNet Version which also indoicate version for EZSP (EmberZNet Serial Protocol)
 * 115200 = Baud rate speed set to 115200
 * 57600 = Baud rate speed set to 57600


### PR DESCRIPTION
Mention "hw" (hardware flow control) in abbreviations legend:

* _nsw = no flow control_
* _sw = software flow control (XON/XOFF flow control)_
* _**hw = hardware flow control (RTS/CTS flow control)**_

Hardware flow control is recommended by OpenHAB developers if firmware and dongle supports it.

Hardware flow control is however not yet supported by Home Assistant ZHA yet but it will be soon.